### PR TITLE
Add RAM and battery descriptors for Pocket Camera cartridges

### DIFF
--- a/Source/GameboyClassicCartridgeConfiguration.swift
+++ b/Source/GameboyClassicCartridgeConfiguration.swift
@@ -256,9 +256,10 @@ extension GameboyClassic.Cartridge {
             if hasSensor  { type += "+\(ExternalHardware.sensor.description)" }
             if hasRumble  { type += "+\(ExternalHardware.rumble.description)" }
             if hasTimer   { type += "+\(ExternalHardware.timer.description)" }
-            if hasRAM && type != "MBC2"
+            if hasRAM && self != .camera && type != "MBC2"
             { type += "+\(ExternalHardware.ram.description)" }
-            if hasBattery { type += "+\(ExternalHardware.battery.description)" }
+            if hasBattery && self != .camera
+            { type += "+\(ExternalHardware.battery.description)" }
             
             return type
         }

--- a/Source/GameboyClassicCartridgeConfiguration.swift
+++ b/Source/GameboyClassicCartridgeConfiguration.swift
@@ -167,6 +167,8 @@ extension GameboyClassic.Cartridge {
                 return true
             case .huc1:
                 return true
+            case .camera:
+                return true
             default:
                 return false
             }
@@ -189,6 +191,8 @@ extension GameboyClassic.Cartridge {
             case .seven:
                 return true
             case .huc1:
+                return true
+            case .camera:
                 return true
             default:
                 return false

--- a/Tests/PlatformTests/GameboyClassicConfigurationTests.swift
+++ b/Tests/PlatformTests/GameboyClassicConfigurationTests.swift
@@ -194,7 +194,7 @@ class MemoryControllerTests: XCTestCase {
                     guard case .camera = mbc else {
                         return XCTFail()
                     }
-                    XCTAssertEqual(mbc.hardware, [.camera])
+                    XCTAssertEqual(mbc.hardware, [.ram, .battery, .camera])
                     XCTAssertEqual(mbc.debugDescription, "POCKET CAMERA")
                     configsTested.fulfill()
                 case 0xFD:


### PR DESCRIPTION
The descriptors for the Pocket Camera cartridge type previously reported it as not having any RAM. It has RAM and a battery.

I’ve confirmed that with this patch, [CartBoy](https://github.com/KevinVitale/CartBoy) becomes capable of dumping the Pocket Camera cartridge’s RAM, and it precisely matches that produced by the GBxCart tools! I’ve also confirmed that the included test cases all pass.

In this PR, I’ve attempted to follow your code style and commit message conventions. I’ve also followed what I presume to be an intent to hide “implicit” hardware features in the `debugDescription` (it looks like MBC2 always has RAM, battery optional, thus it suppressing the “+RAM” - I followed this pattern for the camera!)

Fixes #1